### PR TITLE
Setup GitHub Actions to send pull request number to endpoint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,4 +26,4 @@ jobs:
         if: always()  # This ensures this step runs even if previous steps fail
         run: |
           echo "Calling API endpoint..."
-          curl -X POST -H "Content-Type: application/json" -d '{"pull_request_number": "${{ github.event.pull_request.number }}"}' https:/f986-23-112-11-217.ngrok-free.app/review_build_error_logs
+          curl -X POST -H \"Content-Type: application/json\" -d '{\"pull_request_number\": \"${{ github.event.pull_request.number }}\"}' https:/f986-23-112-11-217.ngrok-free.app/test


### PR DESCRIPTION
This pull request sets up GitHub Actions to send the pull request number to a specified endpoint upon each build, regardless of success or failure.