### PR TITLE
Update GitHub Actions endpoint to review_build_error_logs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build and Notify
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup build environment
+      run: |
+        echo "Setting up build environment..."
+        # Add your setup commands here
+    
+    - name: Build project
+      id: build
+      continue-on-error: true  # This allows the workflow to continue even if this step fails
+      run: |
+        echo "Building project..."
+        # Add your build commands here
+    
+    - name: Call API endpoint regardless of build result
+      if: always()  # This ensures this step runs even if previous steps fail
+      run: |
+        echo "Calling API endpoint..."
+        curl -X POST -H 'Content-Type: application/json' -d '{\"pull_request_number\": \"${{ github.event.pull_request.number }}\"}' https://9da3-23-112-11-217.ngrok-free.app/review_build_error_logs


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to call the `/review_build_error_logs` endpoint instead of `/test`.