### PR TITLE
Add test case for adding task with status

### DIFF
--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -24,3 +24,15 @@ def test_add_task_no_description():
     # Clean up test file
     if os.path.exists('test_tasks.json'):
         os.remove('test_tasks.json')
+
+def test_add_task_with_status():
+    task_manager = TaskManager('test_tasks.json') # Use a separate test json file
+    task = task_manager.add_task('Test Task', 'Test Description', 'Pending')
+    assert task is not None
+    assert task.title == 'Test Task'
+    assert task.description == 'Test Description'
+    assert task.status == 'Pending'
+
+    # Clean up test file
+    if os.path.exists('test_tasks.json'):
+        os.remove('test_tasks.json')


### PR DESCRIPTION
This pull request adds a new test case `test_add_task_with_status` to `tests/test_task_manager.py`. This test case is intended to verify the functionality of adding tasks with a status. Currently, the `add_task` function does not support a status parameter, so the test is expected to fail. This PR is to add the test case to highlight the missing feature and prepare for its implementation in future iterations.