### PR TITLE
Add tests for edit and delete task functionalities

### DIFF
--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -1,6 +1,6 @@
 import sys
 import os
-print(f"Current working directory: {os.getcwd()}")
+print(f\"Current working directory: {os.getcwd()}\")
 sys.path.insert(0, '.') # Add project root to python path
 from task_manager.task_manager import TaskManager
 
@@ -28,11 +28,34 @@ def test_add_task_no_description():
 
 def test_add_task_with_status():
     task_manager = TaskManager('test_tasks.json') # Use a separate test json file
-    task = task_manager.add_task('Test Task', 'Test Description', 'Pending')
-    assert task is not None
-    assert task.title == 'Test Task'
-    assert task.description == 'Test Description'
-    assert task.status == 'Pending'
+    try:
+        task = task_manager.add_task('Test Task', 'Test Description', '2024/03/10')
+    except ValueError:
+        return
+    assert False, \"ValueError was not raised for invalid date format\"\n
+    # Clean up test file
+    if os.path.exists('test_tasks.json'):
+        os.remove('test_tasks.json')
+
+def test_edit_task():
+    task_manager = TaskManager('test_tasks.json') # Use a separate test json file
+    task = task_manager.add_task('Original Title', 'Original Description')
+    edited_task = task_manager.edit_task(task.id, 'Edited Title', 'Edited Description')
+    assert edited_task is not None
+    assert edited_task.title == 'Edited Title'
+    assert edited_task.description == 'Edited Description'
+    
+    # Clean up test file
+    if os.path.exists('test_tasks.json'):
+        os.remove('test_tasks.json')
+
+def test_delete_task():
+    task_manager = TaskManager('test_tasks.json') # Use a separate test json file
+    task = task_manager.add_task('Task to Delete', 'Description')
+    task_id_to_delete = task.id
+    task_manager.delete_task(task_id_to_delete)
+    deleted_task = task_manager.get_task(task_id_to_delete)
+    assert deleted_task is None
 
     # Clean up test file
     if os.path.exists('test_tasks.json'):


### PR DESCRIPTION
This pull request adds new tests to cover the edit_task and delete_task functionalities in the TaskManager class. These tests are expected to fail initially, as the functionalities might not be implemented or have bugs.