### PR TITLE
Fix Build Trigger Configuration

### DIFF
--- a/.github/workflows/review-build.yml
+++ b/.github/workflows/review-build.yml
@@ -2,7 +2,7 @@ name: Review Build Notify
 
 on:
     pull_request:
-        types: [opened]
+        types: [opened, reopened, synchronize]
         branches: [ main, develop ]
 
 jobs:
@@ -11,10 +11,8 @@ jobs:
 
         steps:
             - uses: actions/checkout@v3
-        
             - name: Call API endpoint regardless of build result
               if: always()  # This ensures this step runs even if previous steps fail
               run: |
-                echo "Calling API endpoint..."
-                curl -X POST -H 'Content-Type: application/json' -d '{"pull_request_number": "${{ github.event.pull_request.number }}"}' https:/1381-23-112-11-217.ngrok-free.app/review_build_error_logs
-    
+                echo \"Calling API endpoint...\"
+                curl -X POST -H 'Content-Type: application/json' -d '{\"pull_request_number\": \"${{ github.event.pull_request.number }}\"}' https://1381-23-112-11-217.ngrok-free.app/review_build_error_logs


### PR DESCRIPTION
This pull request modifies the `.github/workflows/review-build.yml` file to correct the build trigger. Specifically, it adds `reopened` and `synchronize` to the `pull_request: types:` to ensure that builds are triggered when a pull request is updated and also adds `synchronize` to the trigger to account for any commits added to an existing pull request.