### PR TITLE
Add test case to check task creation with empty title

### DIFF
--- a/task_manager/test_task_manager.py
+++ b/task_manager/test_task_manager.py
@@ -104,3 +104,8 @@ def test_add_task_with_priority(task_manager):
     assert task.title == 'New Task'
     assert task.priority == 'high'
     assert len(task_manager.list_tasks()) == 1
+
+
+def test_add_task_with_empty_title(task_manager):
+    task = task_manager.add_task(title='')
+    assert task is None


### PR DESCRIPTION
This pull request adds a test case `test_add_task_with_empty_title` to verify that the application does not allow creating tasks with empty titles. The test is currently failing, indicating a bug where empty titles are accepted.