### PR TITLE
Fix: Prevent tasks from being created with empty titles (TM-1428)

### DIFF
--- a/task_manager/task_manager.py
+++ b/task_manager/task_manager.py
@@ -35,6 +35,9 @@ class TaskManager:
         Returns:
             Task: The newly created task object
         """
+        if not title:
+            raise ValueError("Task title cannot be empty.")
+
         if due_date:
             try:
                 due_date = datetime.datetime.strptime(due_date, "%Y-%m-%d").date()


### PR DESCRIPTION
This pull request implements validation in the `add_task` function to ensure that task titles cannot be empty, addressing the issue reported in TM-1428.