### PR TITLE
Fix: TaskManager add_task test bug

### DIFF
--- a/task_manager/test_task_manager.py
+++ b/task_manager/test_task_manager.py
@@ -6,6 +6,7 @@ class TestTaskManager(unittest.TestCase):
 
     def setUp(self):
         self.task_manager = TaskManager(':memory:') # Use in-memory storage for tests
+        self.task_manager.tasks = [] # Clear tasks before each test
 
     def test_add_task(self):
         task = self.task_manager.add_task('Test task', 'This is a test description')


### PR DESCRIPTION
Fixes the issue where `add_task` function in `TaskManager` adds two tasks instead of one in tests by clearing the task list in `setUp` method in test file.