### PR TITLE
Add failing test case for edit_task functionality

### DIFF
--- a/task_manager/test_task_manager.py
+++ b/task_manager/test_task_manager.py
@@ -83,6 +83,12 @@ class TestTaskManager(unittest.TestCase):
         self.assertEqual(stats['priorities']['medium'], 1)
         self.assertEqual(stats['priorities']['low'], 1)
 
+    def test_edit_task(self):
+        task = self.task_manager.add_task('Original Title', 'Original Description')
+        updated_task = self.task_manager.edit_task(task.id, 'Updated Title', 'Updated Description')
+        self.assertEqual(updated_task.title, 'Updated Title')
+        self.assertEqual(updated_task.description, 'Updated Description')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request introduces a failing test case for the `edit_task` functionality in `test_task_manager.py`. The test is expected to fail because the `edit_task` method is not yet implemented in the `TaskManager` class. This PR aims to highlight the missing functionality and provide a basis for future implementation.