### PR TITLE
Add test case for edit_task functionality (failing)

### DIFF
--- a/task_manager/test_task_manager.py
+++ b/task_manager/test_task_manager.py
@@ -95,6 +95,12 @@ class TestTaskManager(unittest.TestCase):
         self.assertEqual(updated_task.title, 'Original Title')
         self.assertEqual(updated_task.description, 'Updated Description')
 
+    def test_edit_task_title(self):
+        task = self.task_manager.add_task('Original Title', 'Original Description')
+        updated_task = self.task_manager.edit_task(task.id, 'Updated Title', None)
+        self.assertEqual(updated_task.title, 'Updated Title')
+        self.assertEqual(updated_task.description, 'Original Description')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request introduces a test case for the `edit_task` functionality. The test is currently failing because the `edit_task` function is not implemented in the `TaskManager` class. This is intentional, as per the instructions to create a pull request with a failing test and not fix the bug.