### PR TITLE
Add test case for editing task due date and show bug

### DIFF
--- a/task_manager/test_task_manager.py
+++ b/task_manager/test_task_manager.py
@@ -100,3 +100,11 @@ class TestTaskManager(unittest.TestCase):
         self.assertTrue(edited_task)
         task = self.task_manager.get_task_by_id(task.id)
         self.assertEqual(task.priority, 'high')
+
+    def test_edit_task_due_date(self):
+        task = self.task_manager.add_task('Task to edit', 'Description')
+        due_date = datetime.date(2024, 1, 1)
+        edited_task = self.task_manager.edit_task(task.id, due_date=due_date)
+        self.assertTrue(edited_task)
+        task = self.task_manager.get_task_by_id(task.id)
+        self.assertEqual(task.due_date, due_date)


### PR DESCRIPTION
This pull request adds a test case `test_edit_task_due_date` to demonstrate a bug in the `edit_task` function when handling due dates. The test is intentionally failing to highlight this issue.