### PR TITLE
Add test case for add_task with due date

### DIFF
--- a/task_manager/test_task_manager.py
+++ b/task_manager/test_task_manager.py
@@ -124,3 +124,12 @@ class TestTaskManager(unittest.TestCase):
     def test_add_task_empty_description(self):
         with self.assertRaises(ValueError):
             task = self.task_manager.add_task('Test task', '')
+
+    def test_add_task_with_due_date(self):
+        due_date = datetime.date(2024, 1, 1)
+        task = self.task_manager.add_task('Task with due date', 'This is a test description with due date', due_date=due_date)
+        self.assertIsNotNone(task.id)
+        self.assertEqual(task.title, 'Task with due date')
+        self.assertEqual(task.description, 'This is a test description with due date')
+        self.assertEqual(task.due_date, due_date)
+        self.assertEqual(len(self.task_manager.tasks), 1)


### PR DESCRIPTION
This pull request adds a new test case `test_add_task_with_due_date` to `test_task_manager.py` to verify the functionality of adding tasks with due dates. The tests are currently failing due to bugs in the code, which are reported in Jira issues [Bug: ValueError not raised when adding task with empty description in add_task method] and [Bug: TypeError in add_task when due_date is datetime.date object].