### PR TITLE
Test: Add test for invalid priority in edit_task

### DIFF
--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -130,6 +130,12 @@ class TestTaskManager(unittest.TestCase):
         edited_task = self.task_manager.get_task_by_id(task.id)
         self.assertEqual(edited_task.priority, 'high')
 
+    def test_edit_task_invalid_priority(self):
+        task = self.task_manager.add_task('Title', 'Description')
+        with self.assertRaises(ValueError) as context:
+            self.task_manager.edit_task(task.id, priority='invalid_priority')
+        self.assertEqual(str(context.exception), 'Priority must be one of: low, medium, high')
+
     def test_complete_task(self):
         task = self.task_manager.add_task('Complete Task Test', 'Description for complete task test')
         self.assertEqual(task.status, TaskStatus.PENDING)

--- a/tests/test_task_manager_add_task.py
+++ b/tests/test_task_manager_add_task.py
@@ -21,3 +21,8 @@ class TestTaskManagerAddTask(unittest.TestCase):
     def test_add_task_default_priority(self):
         task = self.task_manager.add_task('Default Priority Task', 'Description')
         self.assertEqual(task.priority, 'medium')
+
+    def test_add_task_invalid_priority(self):
+        with self.assertRaises(ValueError) as context:
+            self.task_manager.add_task('Invalid Priority Task', 'Description', priority='invalid_priority')
+        self.assertEqual(str(context.exception), 'Priority must be one of: low, medium, high')


### PR DESCRIPTION
This pull request adds a test case to ensure that `edit_task` function raises a ValueError when an invalid priority is provided.