### PR TITLE
Add failing test case for invalid priority in edit_task

### DIFF
--- a/tests/test_task_manager_errors.py
+++ b/tests/test_task_manager_errors.py
@@ -46,3 +46,9 @@ class TestTaskManagerErrors(unittest.TestCase):
         self.assertTrue(self.task_manager.edit_task(task.id, priority='invalid_priority'))
         edited_task = self.task_manager.get_task_by_id(task.id)
         self.assertEqual(edited_task.priority, 'invalid_priority') # Should be handled in Task class or TaskManager
+
+    def test_edit_task_invalid_priority_value_error(self):
+        task = self.task_manager.add_task('Task to Edit Priority', 'Description')
+        with self.assertRaises(ValueError) as context:
+            self.task_manager.edit_task(task.id, priority='invalid-priority')
+        self.assertEqual(str(context.exception), "Invalid priority value: invalid-priority. Priority must be one of: low, medium, high.")


### PR DESCRIPTION
This pull request adds a failing test case to demonstrate that the `edit_task` function does not raise a ValueError when an invalid priority is provided. This highlights a missing validation in the code.