### PR TITLE
Test: Implement test case for Task.from_dict missing title key

### DIFF
--- a/tests/task_manager/test_task.py
+++ b/tests/task_manager/test_task.py
@@ -94,5 +94,18 @@ class TestTask(unittest.TestCase):
         task = Task("Invalid Priority Task", priority="invalid")
         self.assertEqual(task.priority, "invalid") # It should accept invalid priority, no validation
 
+    def test_task_from_dict_missing_title(self):
+        task_dict = {
+            'id': str(uuid.uuid4()),
+            'description': 'Creating task from dict',
+            'due_date': '2024-03-10',
+            'priority': 'high',
+            'status': 'In Progress',
+            'created_date': datetime.date(2024, 1, 1).isoformat(),
+            'completed_date': None
+        }
+        with self.assertRaises(KeyError):
+            Task.from_dict(task_dict)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request adds a test case to verify the error handling of the `Task.from_dict` method when the 'title' key is missing. The test is currently designed to fail as the method does not yet implement the error handling.