### PR TITLE
Test: Add test case for TaskStorage load_tasks with invalid JSON format (TM-1577)

### DIFF
--- a/tests/test_task_storage.py
+++ b/tests/test_task_storage.py
@@ -90,3 +90,14 @@ class TestTaskStorage(unittest.TestCase):
 
         # Assert that it returns an empty list or handles it appropriately
         self.assertEqual(tasks, [])
+
+    def test_load_tasks_invalid_json(self):
+        # Create a test file with invalid JSON format
+        with open(self.test_file, 'w') as f:
+            f.write('{\"invalid_json\": syntax error')
+
+        # Load tasks, should handle invalid JSON and return empty list
+        tasks = self.task_storage.load_tasks()
+
+        # Assert that it returns an empty list
+        self.assertEqual(tasks, [])


### PR DESCRIPTION
This pull request adds a test case to verify that `TaskStorage.load_tasks()` correctly handles invalid JSON format in the task file. The test ensures that the function gracefully returns an empty list when encountering invalid JSON, as expected.

This addresses Jira issue: TM-1577