### PR TITLE
Add test case for TM-1581: Test CLI list command when tasks exist

### DIFF
--- a/tests/test_task_cli.py
+++ b/tests/test_task_cli.py
@@ -13,5 +13,15 @@ class TestTaskCLI(unittest.TestCase):
         process = subprocess.run(['python3', '-m', 'task_manager.task_cli'], capture_output=True, text=True, check=True)
         self.assertIn('usage: task_cli.py', process.stdout)
 
+    def test_cli_list_tasks_when_tasks_exist(self):
+        # Add a task
+        add_process = subprocess.run(['python3', '-m', 'task_manager.task_cli', 'add', 'Test task'], capture_output=True, text=True, check=True)
+        self.assertIn('Task added successfully', add_process.stdout)
+
+        # List tasks
+        list_process = subprocess.run(['python3', '-m', 'task_manager.task_cli', 'list'], capture_output=True, text=True, check=True)
+        self.assertIn('Test task', list_process.stdout)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull request adds a test case to verify the `list` command in the CLI when tasks exist, as described in Jira issue TM-1581. The test case is located in `tests/test_task_cli.py` and is named `test_cli_list_tasks_when_tasks_exist`. The test is expected to fail currently due to a TypeError in the `add` command, which is being tracked in a separate bug issue.