### PR TITLE
Fix: Correct parameter name for TaskManager initialization in task_cli.py (TM-1593)

### DIFF
--- a/task_manager/task_cli.py
+++ b/task_manager/task_cli.py
@@ -8,6 +8,7 @@ import argparse
 import datetime
 import sys
 from task_manager import TaskManager
+from task_manager.task import TaskStatus
 
 
 def format_task_output(task, verbose=False):
@@ -20,13 +21,13 @@ def format_task_output(task, verbose=False):
     Returns:
         str: Formatted task string
     """
-    status = "✓" if task.completed else "☐"
+    status = "✓" if task.status == TaskStatus.COMPLETED else "☐"
     
     if verbose:
         result = f"{status} [{task.id}] {task.title} (Priority: {task.priority})\n"
         result += f"  Created: {task.created_date}"
         
-        if task.completed:
+        if task.status == TaskStatus.COMPLETED:
             result += f" | Completed: {task.completed_date}"
             
         if task.due_date:
@@ -47,7 +48,7 @@ def list_tasks_command(args):
     Args:
         args: Command line arguments
     """
-    manager = TaskManager(task_file='/tmp/task_manager_tests/test_tasks.json')
+    manager = TaskManager(storage_path='/tmp/task_manager_tests/test_tasks.json')
     tasks = manager.list_tasks(show_completed=args.all)
     
     if not tasks:
@@ -65,7 +66,7 @@ def add_task_command(args):
     Args:
         args: Command line arguments
     """
-    manager = TaskManager(task_file='/tmp/task_manager_tests/test_tasks.json')
+    manager = TaskManager(storage_path='/tmp/task_manager_tests/test_tasks.json')
     try:
         task = manager.add_task(
             title=args.title,
@@ -84,7 +85,7 @@ def complete_task_command(args):
     Args:
         args: Command line arguments
     """
-    manager = TaskManager(task_file='/tmp/task_manager_tests/test_tasks.json')
+    manager = TaskManager(storage_path='/tmp/task_manager_tests/test_tasks.json')
     if manager.complete_task(args.id):
         print(f"Task {args.id} marked as completed")
     else:
@@ -97,7 +98,7 @@ def delete_task_command(args):
     Args:
         args: Command line arguments
     """
-    manager = TaskManager(task_file='/tmp/task_manager_tests/test_tasks.json')
+    manager = TaskManager(storage_path='/tmp/task_manager_tests/test_tasks.json')
     if manager.delete_task(args.id):
         print(f"Task {args.id} deleted")
     else:
@@ -110,7 +111,7 @@ def view_task_command(args):
     Args:
         args: Command line arguments
     """
-    manager = TaskManager(task_file='/tmp/task_manager_tests/test_tasks.json')
+    manager = TaskManager(storage_path='/tmp/task_manager_tests/test_tasks.json')
     task = manager.get_task_by_id(args.id)
     if task:
         print(format_task_output(task, verbose=True))
@@ -124,7 +125,7 @@ def stats_command(args):
     Args:
         args: Command line arguments
     """
-    manager = TaskManager(task_file='/tmp/task_manager_tests/test_tasks.json')
+    manager = TaskManager(storage_path='/tmp/task_manager_tests/test_tasks.json')
     stats = manager.get_statistics()
     
     print("Task Statistics:")


### PR DESCRIPTION
Fixes TypeError in TaskManager initialization by correcting the parameter name from `task_file` to `storage_path` in `task_cli.py`, as reported in TM-1593.