### PR TITLE
Test README.md examples

### DIFF
--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -1,0 +1,18 @@
+# tests/test_readme_examples.py
+import subprocess
+
+def test_readme_examples():
+    commands = [
+        'python3 -m task_manager.task_cli add "Implement new feature" -d "Add user authentication" --due 2025-04-01 -p high',
+        'python3 -m task_manager.task_cli list',
+        'python3 -m task_manager.task_cli list -a',
+        'python3 -m task_manager.task_cli list -v',
+        'python3 -m task_manager.task_cli complete 1',
+        'python3 -m task_manager.task_cli delete 1',
+        'python3 -m task_manager.task_cli view 1',
+        'python3 -m task_manager.task_cli stats',
+        'python3 -m task_manager.task_cli --help'
+    ]
+    for command in commands:
+        process = subprocess.run(command, shell=True, capture_output=True)
+        assert process.returncode == 0


### PR DESCRIPTION
This pull request adds tests to verify the command examples in README.md. The tests are currently failing because the example for the `add` command in README.md includes invalid arguments `--due` and `-p`. This PR includes the failing test to highlight this discrepancy.