### PR TITLE
Add test case for Task.from_dict missing title error handling - TM-1606

### DIFF
--- a/tests/task_manager/test_task.py
+++ b/tests/task_manager/test_task.py
@@ -105,8 +105,9 @@ class TestTask(unittest.TestCase):
             'created_date': datetime.date(2024, 1, 1).isoformat(),
             'completed_date': None
         }
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ValueError) as context:
             Task.from_dict(task_dict)
+        self.assertIn("title", str(context.exception).lower())
 
 class TestTaskDocumentation(unittest.TestCase):
 


### PR DESCRIPTION
This pull request adds a test case to verify that `Task.from_dict` method raises a `ValueError` with an informative error message when the 'title' key is missing from the input dictionary, as requested in Jira issue TM-1606.