### PR TITLE
feat: Add test case for missing 'id' in Task.from_dict (TM-1607)

### DIFF
--- a/tests/task_manager/test_task.py
+++ b/tests/task_manager/test_task.py
@@ -109,6 +109,20 @@ class TestTask(unittest.TestCase):
             Task.from_dict(task_dict)
         self.assertIn("title", str(context.exception).lower())
 
+    def test_task_from_dict_missing_id(self):
+        task_dict = {
+            'title': 'Missing ID Task',
+            'description': 'Creating task from dict without id',
+            'due_date': '2024-03-15',
+            'priority': 'medium',
+            'status': 'Pending',
+            'created_date': datetime.date(2024, 1, 5).isoformat(),
+            'completed_date': None
+        }
+        with self.assertRaises(ValueError) as context:
+            Task.from_dict(task_dict)
+        self.assertIn("id", str(context.exception).lower())
+
 class TestTaskDocumentation(unittest.TestCase):
 
     def test_task_class_docstring(self):


### PR DESCRIPTION
This pull request adds a test case to verify that `Task.from_dict` method raises a `ValueError` with an informative error message when the 'id' key is missing from the input dictionary, as requested in issue TM-1607.