### PR TITLE
Test: Add test case for Task.from_dict error handling - missing created_date (TM-1609)

### DIFF
--- a/tests/task_manager/test_task.py
+++ b/tests/task_manager/test_task.py
@@ -138,6 +138,21 @@ class TestTask(unittest.TestCase):
         self.assertIn("description", str(context.exception).lower())
         self.assertIn("missing description", str(context.exception).lower())
 
+    def test_task_from_dict_missing_created_date(self):
+        task_dict = {
+            'id': str(uuid.uuid4()),
+            'title': 'Missing Created Date Task',
+            'description': 'Creating task from dict without created_date',
+            'due_date': '2024-03-15',
+            'priority': 'medium',
+            'status': 'Pending',
+            'completed_date': None
+        }
+        with self.assertRaises(ValueError) as context:
+            Task.from_dict(task_dict)
+        self.assertIn("created_date", str(context.exception).lower())
+        self.assertIn("missing created date", str(context.exception).lower())
+
 class TestTaskDocumentation(unittest.TestCase):
 
     def test_task_class_docstring(self):


### PR DESCRIPTION
This pull request adds a test case to verify that `Task.from_dict` method raises a `ValueError` with an informative error message when the 'created_date' key is missing from the input dictionary, as requested in issue TM-1609.