### PR TITLE
Fix: Add test case for missing 'priority' key in Task.from_dict

### DIFF
--- a/tests/task_manager/test_task.py
+++ b/tests/task_manager/test_task.py
@@ -168,6 +168,21 @@ class TestTask(unittest.TestCase):
         self.assertIn("status", str(context.exception).lower())
         self.assertIn("missing status", str(context.exception).lower())
 
+    def test_task_from_dict_missing_priority(self):
+        task_dict = {
+            'id': str(uuid.uuid4()),
+            'title': 'Missing Priority Task',
+            'description': 'Creating task from dict without priority',
+            'due_date': '2024-03-15',
+            'status': 'Pending',
+            'created_date': datetime.date(2024, 1, 5).isoformat(),
+            'completed_date': None
+        }
+        with self.assertRaises(ValueError) as context:
+            Task.from_dict(task_dict)
+        self.assertIn("priority", str(context.exception).lower())
+        self.assertIn("missing priority", str(context.exception).lower())
+
 class TestTaskDocumentation(unittest.TestCase):
 
     def test_task_class_docstring(self):


### PR DESCRIPTION
This pull request adds a test case to verify that the `Task.from_dict` method handles the case where the 'priority' key is missing in the input dictionary, as requested in Jira issue TM-1610.