### PR TITLE
Test: Handle missing 'due_date' in Task.from_dict

### DIFF
--- a/tests/task_manager/test_task.py
+++ b/tests/task_manager/test_task.py
@@ -196,6 +196,19 @@ class TestTask(unittest.TestCase):
         task = Task.from_dict(task_dict)
         self.assertEqual(task.priority, 'medium')
 
+    def test_task_from_dict_missing_due_date(self):
+        task_dict = {
+            'id': str(uuid.uuid4()),
+            'title': 'Missing Due Date Task',
+            'description': 'Creating task from dict without due_date',
+            'priority': 'medium',
+            'status': 'Pending',
+            'created_date': datetime.date(2024, 1, 5).isoformat(),
+            'completed_date': None
+        }
+        task = Task.from_dict(task_dict)
+        self.assertIsNone(task.due_date)
+
 class TestTaskDocumentation(unittest.TestCase):
 
     def test_task_class_docstring(self):


### PR DESCRIPTION
This pull request adds a test case to verify that the `Task.from_dict` method correctly handles the case where the 'due_date' key is missing in the input dictionary. The test ensures that when 'due_date' is missing, the `task.due_date` attribute is set to None.

The test case `test_task_from_dict_missing_due_date` has been added to `tests/task_manager/test_task.py` and is passing.