### PR TITLE
Failing test case for TM-1613: Task.from_dict method handles missing 'completed_date' key

### DIFF
--- a/tests/task_manager/test_task.py
+++ b/tests/task_manager/test_task.py
@@ -209,6 +209,19 @@ class TestTask(unittest.TestCase):
         task = Task.from_dict(task_dict)
         self.assertIsNone(task.due_date)
 
+    def test_task_from_dict_missing_completed_date(self):
+        task_dict = {
+            'id': str(uuid.uuid4()),
+            'title': 'Missing Completed Date Task',
+            'description': 'Creating task from dict without completed_date',
+            'due_date': '2024-03-15',
+            'priority': 'medium',
+            'status': 'Pending',
+            'created_date': datetime.date(2024, 1, 5).isoformat()
+        }
+        task = Task.from_dict(task_dict)
+        self.assertIsNone(task.completed_date)
+
 class TestTaskDocumentation(unittest.TestCase):
 
     def test_task_class_docstring(self):


### PR DESCRIPTION
This pull request introduces a failing test case to verify that the `Task.from_dict` method correctly handles dictionaries without the 'completed_date' key as per Jira issue TM-1613.