### PR TITLE
Fix test for TM-1577

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,5 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+task-tracker-python-fresh/


### PR DESCRIPTION
This pull request fixes the test related to TM-1577 and excludes the `task-tracker-python-fresh/` directory from the pull request by adding it to .gitignore.